### PR TITLE
Feat. Distributed Data Parallel for Trainer

### DIFF
--- a/networks/managers/trainer.py
+++ b/networks/managers/trainer.py
@@ -30,8 +30,8 @@ class Trainer(object):
         self.device = device if device is not None else torch.device("cpu")
         self.use_cuda = self.device.type == "cuda"
         if not self.use_cuda: cfg.DIST_ENABLE = False
-        self.gpu = rank + cfg.DIST_START_GPU
-        self.gpu_num = cfg.TRAIN_GPUS 
+        self.gpu = self.device.index if self.use_cuda else None
+        self.gpu_num = cfg.TRAIN_GPUS
         self.rank = rank
         self.cfg = cfg
 
@@ -43,7 +43,6 @@ class Trainer(object):
         else:
             print("Using CPU")
         if self.use_cuda:
-            torch.cuda.set_device(self.gpu)
             torch.backends.cudnn.benchmark = True if cfg.DATA_RANDOMCROP[
                 0] == cfg.DATA_RANDOMCROP[
                     1] and 'swin' not in cfg.MODEL_ENCODER else False
@@ -56,23 +55,13 @@ class Trainer(object):
             cfg.MODEL_ENGINE,
             'train',
             aot_model=self.model,
-            gpu_id=self.gpu if self.use_cuda else None,
+            gpu_id=self.device.index if self.use_cuda else None,
             long_term_mem_gap=cfg.TRAIN_LONG_TERM_MEM_GAP
         )
 
         if cfg.MODEL_FREEZE_BACKBONE:
             for param in self.model_encoder.parameters():
                 param.requires_grad = False
-
-        if cfg.DIST_ENABLE:
-            backend = "nccl" if self.use_cuda else "gloo"
-            dist.init_process_group(
-                backend=backend,
-                init_method=cfg.DIST_URL,
-                world_size=cfg.TRAIN_GPUS,
-                rank=rank,
-                timeout=datetime.timedelta(seconds=300)
-            )
 
         if self.use_cuda:
             self.model.encoder = nn.SyncBatchNorm.convert_sync_batchnorm(
@@ -83,8 +72,8 @@ class Trainer(object):
             if self.use_cuda:
                 self.dist_engine = torch.nn.parallel.DistributedDataParallel(
                     self.engine,
-                    device_ids=[self.gpu],
-                    output_device=self.gpu,
+                    device_ids=[self.device.index] if self.use_cuda else None,
+                    output_device=self.device.index if self.use_cuda else None,
                     find_unused_parameters=True,
                     broadcast_buffers=False
                 )
@@ -276,7 +265,7 @@ class Trainer(object):
                         cfg.MODEL_ENCODER_PRETRAIN))
 
     def prepare_dataset(self):
-     
+
         cfg = self.cfg
         print(">>> DATASETS AT RUNTIME:", cfg.DATASETS)
         self.enable_prev_frame = cfg.TRAIN_ENABLE_PREV_FRAME
@@ -474,13 +463,13 @@ class Trainer(object):
                                        dim=0)
                 all_labels = torch.cat([ref_labels, prev_labels] + curr_labels,
                                        dim=0)
-
+                if self.use_cuda: torch.cuda.set_device(self.device.index)
                 self.engine.restart_engine(batch_size, True)
                 optimizer.zero_grad(set_to_none=True)
 
                 if self.enable_amp:
                     with torch.cuda.amp.autocast(enabled=self.enable_amp):
-                        
+
                         loss, all_pred, all_loss, boards = model(
                             all_frames,
                             all_labels,
@@ -492,17 +481,17 @@ class Trainer(object):
                             enable_prev_frame=self.enable_prev_frame,
                             use_prev_prob=use_prev_prob)
                         loss = torch.mean(loss)
-                        
+
                     start = time.time()
                     self.scaler.scale(loss).backward()
                     end = time.time()
-                    print(end-start)
+                    if self.rank == 0: print(end - start)
                     self.scaler.unscale_(optimizer)
                     torch.nn.utils.clip_grad_norm_(model.parameters(),
                                                    cfg.TRAIN_CLIP_GRAD_NORM)
                     self.scaler.step(optimizer)
                     self.scaler.update()
-                    
+
                 else:
                     loss, all_pred, all_loss, boards = model(
                         all_frames,
@@ -530,8 +519,10 @@ class Trainer(object):
                     if self.cfg.DIST_ENABLE:
                         dist.all_reduce(now_loss)
                         dist.all_reduce(now_iou)
-                        now_loss /= self.gpu_num
-                        now_iou /= self.gpu_num
+                        if self.cfg.DIST_ENABLE:
+                            world_size = dist.get_world_size()
+                            now_loss /= world_size
+                            now_iou /= world_size
                     if self.rank == 0:
                         running_losses[idx].update(now_loss.item())
                         running_ious[idx].update(now_iou.item())
@@ -574,7 +565,7 @@ class Trainer(object):
 
                 if step % cfg.TRAIN_SAVE_STEP == 0 and self.rank == 0:
                     if self.use_cuda:
-                        max_mem = torch.cuda.max_memory_allocated(device=self.gpu) / (1024.**3)
+                        max_mem = torch.cuda.max_memory_allocated(device=self.device) / (1024.**3)
                     else:
                         max_mem = 0
                     ETA = str(

--- a/networks/managers/trainer.py
+++ b/networks/managers/trainer.py
@@ -26,7 +26,10 @@ from networks.engines import build_engine
 
 
 class Trainer(object):
-    def __init__(self, rank, cfg, enable_amp=True):
+    def __init__(self, rank, cfg, enable_amp=True, device=None):
+        self.device = device if device is not None else torch.device("cpu")
+        self.use_cuda = self.device.type == "cuda"
+        if not self.use_cuda: cfg.DIST_ENABLE = False
         self.gpu = rank + cfg.DIST_START_GPU
         self.gpu_num = cfg.TRAIN_GPUS 
         self.rank = rank
@@ -35,43 +38,58 @@ class Trainer(object):
         self.print_log("Exp {}:".format(cfg.EXP_NAME))
         self.print_log(json.dumps(cfg.__dict__, indent=4, sort_keys=True))
 
-        print("Use GPU {} for training VOS.".format(self.gpu))
-        torch.cuda.set_device(self.gpu)
-        torch.backends.cudnn.benchmark = True if cfg.DATA_RANDOMCROP[
-            0] == cfg.DATA_RANDOMCROP[
-                1] and 'swin' not in cfg.MODEL_ENCODER else False
+        if self.use_cuda:
+            print(f"Using CUDA:{self.gpu}")
+        else:
+            print("Using CPU")
+        if self.use_cuda:
+            torch.cuda.set_device(self.gpu)
+            torch.backends.cudnn.benchmark = True if cfg.DATA_RANDOMCROP[
+                0] == cfg.DATA_RANDOMCROP[
+                    1] and 'swin' not in cfg.MODEL_ENCODER else False
 
         self.print_log('Build VOS model.')
 
-        self.model = build_vos_model(cfg.MODEL_VOS, cfg).cuda(self.gpu)
+        self.model = build_vos_model(cfg.MODEL_VOS, cfg).to(self.device)
         self.model_encoder = self.model.encoder
         self.engine = build_engine(
             cfg.MODEL_ENGINE,
             'train',
             aot_model=self.model,
-            gpu_id=self.gpu,
-            long_term_mem_gap=cfg.TRAIN_LONG_TERM_MEM_GAP)
+            gpu_id=self.gpu if self.use_cuda else None,
+            long_term_mem_gap=cfg.TRAIN_LONG_TERM_MEM_GAP
+        )
 
         if cfg.MODEL_FREEZE_BACKBONE:
             for param in self.model_encoder.parameters():
                 param.requires_grad = False
 
         if cfg.DIST_ENABLE:
-            dist.init_process_group(backend=cfg.DIST_BACKEND,
-                                    init_method=cfg.DIST_URL,
-                                    world_size=cfg.TRAIN_GPUS,
-                                    rank=rank,
-                                    timeout=datetime.timedelta(seconds=300))
+            backend = "nccl" if self.use_cuda else "gloo"
+            dist.init_process_group(
+                backend=backend,
+                init_method=cfg.DIST_URL,
+                world_size=cfg.TRAIN_GPUS,
+                rank=rank,
+                timeout=datetime.timedelta(seconds=300)
+            )
 
+        if self.use_cuda:
             self.model.encoder = nn.SyncBatchNorm.convert_sync_batchnorm(
-                self.model.encoder).cuda(self.gpu)
+                self.model.encoder
+            ).to(self.device)
 
-            self.dist_engine = torch.nn.parallel.DistributedDataParallel(
-                self.engine,
-                device_ids=[self.gpu],
-                output_device=self.gpu,
-                find_unused_parameters=True,
-                broadcast_buffers=False)
+        if cfg.DIST_ENABLE:
+            if self.use_cuda:
+                self.dist_engine = torch.nn.parallel.DistributedDataParallel(
+                    self.engine,
+                    device_ids=[self.gpu],
+                    output_device=self.gpu,
+                    find_unused_parameters=True,
+                    broadcast_buffers=False
+                )
+            else:
+                self.dist_engine = torch.nn.parallel.DistributedDataParallel(self.engine)
         else:
             self.dist_engine = self.engine
 
@@ -80,6 +98,7 @@ class Trainer(object):
             self.print_log('Use LN in Encoder!')
         elif not cfg.MODEL_FREEZE_BN:
             if cfg.DIST_ENABLE:
+
                 self.print_log('Use Sync BN in Encoder!')
             else:
                 self.print_log('Use BN in Encoder!')
@@ -120,8 +139,9 @@ class Trainer(object):
                                          lr=cfg.TRAIN_LR,
                                          weight_decay=cfg.TRAIN_WEIGHT_DECAY)
 
-        self.enable_amp = enable_amp
-        if enable_amp:
+        self.enable_amp = enable_amp and self.use_cuda
+
+        if self.enable_amp:
             self.scaler = torch.cuda.amp.GradScaler()
         else:
             self.scaler = None
@@ -159,7 +179,7 @@ class Trainer(object):
                             self.ema_dir,
                             'save_step_%s.pth' % (cfg.TRAIN_RESUME_CKPT))
                         ema_model, removed_dict = load_network(
-                            self.model, ema_ckpt_dir, self.gpu)
+                            self.model, ema_ckpt_dir, self.device)
                     except Exception as inst:
                         self.print_log(inst)
                         self.print_log('Try to use backup EMA checkpoint.')
@@ -170,7 +190,7 @@ class Trainer(object):
                             DIR_EMA_CKPT,
                             'save_step_%s.pth' % (cfg.TRAIN_RESUME_CKPT))
                         ema_model, removed_dict = load_network(
-                            self.model, ema_ckpt_dir, self.gpu)
+                            self.model, ema_ckpt_dir, self.device)
 
                     if len(removed_dict) > 0:
                         self.print_log(
@@ -194,7 +214,7 @@ class Trainer(object):
                     self.model,
                     self.optimizer,
                     resume_ckpt,
-                    self.gpu,
+                    self.device,
                     scaler=self.scaler)
             except Exception as inst:
                 self.print_log(inst)
@@ -227,7 +247,7 @@ class Trainer(object):
             if cfg.PRETRAIN_FULL:
                 try:
                     self.model, removed_dict = load_network(
-                        self.model, cfg.PRETRAIN_MODEL, self.gpu)
+                        self.model, cfg.PRETRAIN_MODEL, self.device)
                 except Exception as inst:
                     self.print_log(inst)
                     self.print_log('Try to use backup EMA checkpoint.')
@@ -238,7 +258,7 @@ class Trainer(object):
                         DIR_EMA_CKPT,
                         cfg.PRETRAIN_MODEL.split('/')[-1])
                     self.model, removed_dict = load_network(
-                        self.model, PRETRAIN_MODEL, self.gpu)
+                        self.model, PRETRAIN_MODEL, self.device)
 
                 if len(removed_dict) > 0:
                     self.print_log('Remove {} from pretrained model.'.format(
@@ -247,7 +267,7 @@ class Trainer(object):
                     cfg.PRETRAIN_MODEL))
             else:
                 model_encoder, removed_dict = load_network(
-                    self.model_encoder, cfg.MODEL_ENCODER_PRETRAIN, self.gpu)
+                    self.model_encoder, cfg.MODEL_ENCODER_PRETRAIN,self.device)
                 if len(removed_dict) > 0:
                     self.print_log('Remove {} from pretrained model.'.format(
                         removed_dict))
@@ -256,7 +276,9 @@ class Trainer(object):
                         cfg.MODEL_ENCODER_PRETRAIN))
 
     def prepare_dataset(self):
+     
         cfg = self.cfg
+        print(">>> DATASETS AT RUNTIME:", cfg.DATASETS)
         self.enable_prev_frame = cfg.TRAIN_ENABLE_PREV_FRAME
 
         self.print_log('Process dataset...')
@@ -330,7 +352,6 @@ class Trainer(object):
             test_dataset = TEST(transform=composed_transforms,
                                 seq_len=cfg.DATA_SEQ_LEN)
             train_datasets.append(test_dataset)
-
         if len(train_datasets) > 1:
             train_dataset = torch.utils.data.ConcatDataset(train_datasets)
         elif len(train_datasets) == 1:
@@ -341,15 +362,15 @@ class Trainer(object):
 
         self.train_sampler = torch.utils.data.distributed.DistributedSampler(
             train_dataset) if self.cfg.DIST_ENABLE else None
+        effective_gpus = max(cfg.TRAIN_GPUS, 1)
         self.train_loader = DataLoader(train_dataset,
-                                       batch_size=int(cfg.TRAIN_BATCH_SIZE /
-                                                      cfg.TRAIN_GPUS),
+                                       batch_size = int(cfg.TRAIN_BATCH_SIZE / effective_gpus),
                                        shuffle=False if self.cfg.DIST_ENABLE else True,
                                        num_workers=cfg.DATA_WORKERS,
-                                       pin_memory=True,
+                                       pin_memory=self.use_cuda,
                                        sampler=self.train_sampler,
                                        drop_last=True,
-                                       prefetch_factor=4)
+                                       prefetch_factor=4 if cfg.DATA_WORKERS > 0 else None)
 
         self.print_log('Done!')
 
@@ -389,7 +410,7 @@ class Trainer(object):
         self.print_log('Start training:')
         model.train()
         while step < cfg.TRAIN_TOTAL_STEPS:
-            if self.cfg.DIST_ENABLE:
+            if self.cfg.DIST_ENABLE and train_sampler is not None:
                 train_sampler.set_epoch(epoch)
             epoch += 1
             last_time = time.time()
@@ -432,16 +453,16 @@ class Trainer(object):
                 obj_nums = sample['meta']['obj_num']
                 bs, _, h, w = curr_imgs[0].size()
 
-                ref_imgs = ref_imgs.cuda(self.gpu, non_blocking=True)
-                prev_imgs = prev_imgs.cuda(self.gpu, non_blocking=True)
+                ref_imgs = ref_imgs.to(self.device, non_blocking=self.use_cuda)
+                prev_imgs = prev_imgs.to(self.device, non_blocking=self.use_cuda)
                 curr_imgs = [
-                    curr_img.cuda(self.gpu, non_blocking=True)
+                    curr_img.to(self.device, non_blocking=self.use_cuda)
                     for curr_img in curr_imgs
                 ]
-                ref_labels = ref_labels.cuda(self.gpu, non_blocking=True)
-                prev_labels = prev_labels.cuda(self.gpu, non_blocking=True)
+                ref_labels = ref_labels.to(self.device, non_blocking=self.use_cuda)
+                prev_labels = prev_labels.to(self.device, non_blocking=self.use_cuda)
                 curr_labels = [
-                    curr_label.cuda(self.gpu, non_blocking=True)
+                    curr_label.to(self.device, non_blocking=self.use_cuda)
                     for curr_label in curr_labels
                 ]
                 obj_nums = list(obj_nums)
@@ -458,7 +479,7 @@ class Trainer(object):
                 optimizer.zero_grad(set_to_none=True)
 
                 if self.enable_amp:
-                    with torch.cuda.amp.autocast(enabled=True):
+                    with torch.cuda.amp.autocast(enabled=self.enable_amp):
                         
                         loss, all_pred, all_loss, boards = model(
                             all_frames,
@@ -516,7 +537,8 @@ class Trainer(object):
                         running_ious[idx].update(now_iou.item())
 
                 if self.rank == 0:
-                    self.ema.update(self.ema_params)
+                    if hasattr(self, "ema"):
+                        self.ema.update(self.ema_params)
 
                     avg_obj.update(sum(obj_nums) / float(len(obj_nums)))
                     curr_time = time.time()
@@ -551,8 +573,10 @@ class Trainer(object):
                 step += 1
 
                 if step % cfg.TRAIN_SAVE_STEP == 0 and self.rank == 0:
-                    max_mem = torch.cuda.max_memory_allocated(
-                        device=self.gpu) / (1024.**3)
+                    if self.use_cuda:
+                        max_mem = torch.cuda.max_memory_allocated(device=self.gpu) / (1024.**3)
+                    else:
+                        max_mem = 0
                     ETA = str(
                         datetime.timedelta(
                             seconds=int(batch_time.moving_avg *
@@ -569,7 +593,8 @@ class Trainer(object):
                                      cfg.EXP_NAME, cfg.STAGE_NAME),
                                  scaler=self.scaler)
                     try:
-                        torch.cuda.empty_cache()
+                        if self.use_cuda:
+                            torch.cuda.empty_cache()
                         # First save original parameters before replacing with EMA version
                         self.ema.store(self.ema_params)
                         # Copy EMA parameters to model

--- a/networks/managers/trainer.py
+++ b/networks/managers/trainer.py
@@ -228,7 +228,7 @@ class Trainer(object):
                     self.model,
                     self.optimizer,
                     resume_ckpt,
-                    self.gpu,
+                    self.device,
                     scaler=self.scaler)
 
             if len(removed_dict) > 0:

--- a/networks/managers/trainer.py
+++ b/networks/managers/trainer.py
@@ -26,22 +26,22 @@ from networks.engines import build_engine
 
 
 class Trainer(object):
-    def __init__(self, rank, cfg, enable_amp=True, device=None):
+    def __init__(self, rank, cfg, enable_amp=True, device=None, world_size=1):
         self.device = device if device is not None else torch.device("cpu")
         self.use_cuda = self.device.type == "cuda"
         if not self.use_cuda: cfg.DIST_ENABLE = False
-        self.gpu = self.device.index if self.use_cuda else None
-        self.gpu_num = cfg.TRAIN_GPUS
+        self.world_size = world_size
         self.rank = rank
         self.cfg = cfg
 
         self.print_log("Exp {}:".format(cfg.EXP_NAME))
         self.print_log(json.dumps(cfg.__dict__, indent=4, sort_keys=True))
 
-        if self.use_cuda:
-            print(f"Using CUDA:{self.gpu}")
-        else:
-            print("Using CPU")
+        if self.rank == 0:
+            if self.use_cuda:
+                print(f"Using CUDA:{self.gpu}")
+            else:
+                print("Using CPU")
         if self.use_cuda:
             torch.backends.cudnn.benchmark = True if cfg.DATA_RANDOMCROP[
                 0] == cfg.DATA_RANDOMCROP[

--- a/networks/managers/trainer.py
+++ b/networks/managers/trainer.py
@@ -34,6 +34,7 @@ class Trainer(object):
         self.rank = rank
         self.cfg = cfg
 
+
         self.print_log("Exp {}:".format(cfg.EXP_NAME))
         self.print_log(json.dumps(cfg.__dict__, indent=4, sort_keys=True))
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,120 +1,164 @@
 import importlib
+import os
 import random
-import sys
+import numpy as np
 import torch
-import torch.multiprocessing as mp
-
-sys.setrecursionlimit(10000)
-sys.path.append('.')
-sys.path.append('..')
 
 from networks.managers.trainer import Trainer
 
-
-def main_worker(rank, cfg, enable_amp=True):
-    # -------- Device Resolution --------
-    use_cuda = torch.cuda.is_available()
-
-    if use_cuda:
-        gpu_id = rank + cfg.DIST_START_GPU
-        device = torch.device(f"cuda:{gpu_id}")
-    else:
-        device = torch.device("cpu")
-        enable_amp = False  # AMP not supported on CPU
-
-    # -------- Debug Info (important) --------
-    print(f"[INFO] Rank: {rank} | Device: {device} | AMP: {enable_amp}")
-
-    # -------- Trainer Init --------
-    trainer = Trainer(
-        rank=rank,
-        cfg=cfg,
-        enable_amp=enable_amp,
-        device=device  # <-- enforce device injection
-    )
-
-    trainer.sequential_training()
-
-
-def main():
+# ----------------------------
+# Argument Parser
+# ----------------------------
+def parse_args():
     import argparse
-    parser = argparse.ArgumentParser(description="Train VOS")
+    parser = argparse.ArgumentParser("Train VOS")
 
+    # experiment
     parser.add_argument('--exp_name', type=str, default='')
     parser.add_argument('--stage', type=str, default='pre')
     parser.add_argument('--model', type=str, default='aott')
-    parser.add_argument('--max_id_num', type=int, default='-1')
 
-    parser.add_argument('--start_gpu', type=int, default=0)
-    parser.add_argument('--gpu_num', type=int, default=-1)
+    # training overrides
     parser.add_argument('--batch_size', type=int, default=-1)
-    parser.add_argument('--dist_url', type=str, default='')
-    parser.add_argument('--amp', action='store_true')
-    parser.set_defaults(amp=False)
-
-    parser.add_argument('--pretrained_path', type=str, default='')
-    parser.add_argument('--datasets', nargs='+', type=str, default=[])
     parser.add_argument('--lr', type=float, default=-1.)
-    parser.add_argument('--total_step', type=int, default=-1.)
-    parser.add_argument('--start_step', type=int, default=-1.)
+    parser.add_argument('--total_step', type=int, default=-1)
 
-    args = parser.parse_args()
+    # data / pretrained
+    parser.add_argument('--datasets', nargs='+', type=str, default=[])
+    parser.add_argument('--pretrained_path', type=str, default='')
 
-    # -------- Load Config --------
+    # AMP
+    parser.add_argument('--amp', action='store_true')
+
+    return parser.parse_args()
+
+
+# ----------------------------
+# Runtime Setup
+# ----------------------------
+def setup_runtime():
+    use_cuda = torch.cuda.is_available()
+    if torch.cuda.device_count() > 1 and not distributed:
+        raise RuntimeError(
+            "Multiple GPUs detected but not using torchrun. "
+            "Launch with: torchrun --nproc_per_node=N train.py"
+        )
+    # CPU fallback
+    if not use_cuda:
+        return {
+            "device": torch.device("cpu"),
+            "rank": 0,
+            "world_size": 1,
+            "distributed": False
+        }
+
+    # DDP via torchrun
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        import torch.distributed as dist
+
+        rank = int(os.environ["RANK"])
+        world_size = int(os.environ["WORLD_SIZE"])
+        local_rank = int(os.environ["LOCAL_RANK"])
+
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group(backend="nccl")
+
+        device = torch.device("cuda", local_rank)
+
+        return {
+            "device": device,
+            "rank": rank,
+            "world_size": world_size,
+            "distributed": True
+        }
+
+    # Single GPU fallback
+    torch.cuda.set_device(0)
+    return {
+        "device": torch.device("cuda:0"),
+        "rank": 0,
+        "world_size": 1,
+        "distributed": False
+    }
+
+
+# ----------------------------
+# Seeding (per-rank)
+# ----------------------------
+def set_seed(base_seed, rank):
+    seed = base_seed + rank
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.backends.cudnn.deterministic = False
+        torch.backends.cudnn.benchmark = True
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+
+# ----------------------------
+# Main
+# ----------------------------
+def main():
+    args = parse_args()
+
+    # -------- Load config --------
     engine_config = importlib.import_module('configs.' + args.stage)
     cfg = engine_config.EngineConfig(args.exp_name, args.model)
 
-    # -------- Override Config --------
-    if len(args.datasets) > 0:
+    # -------- Override config --------
+    if args.datasets:
         cfg.DATASETS = args.datasets
-
-    cfg.DIST_START_GPU = args.start_gpu
-
-    if args.gpu_num > 0:
-        cfg.TRAIN_GPUS = args.gpu_num
-
     if args.batch_size > 0:
         cfg.TRAIN_BATCH_SIZE = args.batch_size
-
-    if args.pretrained_path != '':
-        cfg.PRETRAIN_MODEL = args.pretrained_path
-
-    if args.max_id_num > 0:
-        cfg.MODEL_MAX_OBJ_NUM = args.max_id_num
-
     if args.lr > 0:
         cfg.TRAIN_LR = args.lr
-
     if args.total_step > 0:
         cfg.TRAIN_TOTAL_STEPS = args.total_step
+    if args.pretrained_path:
+        cfg.PRETRAIN_MODEL = args.pretrained_path
 
-    if args.start_step > 0:
-        cfg.TRAIN_START_STEP = args.start_step
+    # -------- Runtime --------
+    runtime = setup_runtime()
 
-    # -------- Dist URL --------
-    if args.dist_url == '':
-        cfg.DIST_URL = 'tcp://127.0.0.1:123' + str(random.randint(0, 99))
-    else:
-        cfg.DIST_URL = args.dist_url
+    device = runtime["device"]
+    rank = runtime["rank"]
+    world_size = runtime["world_size"]
+    distributed = runtime["distributed"]
 
-    # -------- Device Mode Decision --------
-    use_cuda = torch.cuda.is_available()
+    cfg.TRAIN_GPUS = world_size
+    cfg.DIST_ENABLE = distributed
 
-    if not use_cuda:
-        print("[INFO] CUDA not available → Running on CPU")
-        cfg.TRAIN_GPUS = 0
-        main_worker(0, cfg, enable_amp=False)
+    # -------- Seeding --------
+    set_seed(42, rank)
 
-    elif cfg.TRAIN_GPUS > 1:
-        print(f"[INFO] Multi-GPU Training on {cfg.TRAIN_GPUS} GPUs")
-        mp.spawn(main_worker, nprocs=cfg.TRAIN_GPUS, args=(cfg, args.amp))
+    # -------- Logging --------
+    if rank == 0:
+        print(f"[INFO] Rank {rank} | Device {device} | World Size {world_size}")
 
-    else:
-        print("[INFO] Single GPU Training")
-        cfg.TRAIN_GPUS = 1
-        main_worker(0, cfg, enable_amp=args.amp)
+    # -------- AMP --------
+    enable_amp = args.amp and device.type == "cuda"
+
+    # -------- Trainer --------
+    trainer = Trainer(
+        rank=rank,
+        world_size=world_size,
+        cfg=cfg,
+        enable_amp=enable_amp,
+        device=device
+    )
+
+    # -------- Train --------
+    trainer.sequential_training()
+
+    # -------- Cleanup --------
+    if distributed:
+        import torch.distributed as dist
+        dist.barrier()
+        dist.destroy_process_group()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-    

--- a/tools/train.py
+++ b/tools/train.py
@@ -16,7 +16,8 @@ def main_worker(rank, cfg, enable_amp=True):
     use_cuda = torch.cuda.is_available()
 
     if use_cuda:
-        device = torch.device(f"cuda:{rank}")
+        gpu_id = rank + cfg.DIST_START_GPU
+        device = torch.device(f"cuda:{gpu_id}")
     else:
         device = torch.device("cpu")
         enable_amp = False  # AMP not supported on CPU

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,26 +1,44 @@
 import importlib
 import random
 import sys
+import torch
+import torch.multiprocessing as mp
 
 sys.setrecursionlimit(10000)
 sys.path.append('.')
 sys.path.append('..')
 
-import torch.multiprocessing as mp
-
 from networks.managers.trainer import Trainer
 
 
-def main_worker(gpu, cfg, enable_amp=True):
-    # Initiate a training manager
-    trainer = Trainer(rank=gpu, cfg=cfg, enable_amp=enable_amp)
-    # Start Training
+def main_worker(rank, cfg, enable_amp=True):
+    # -------- Device Resolution --------
+    use_cuda = torch.cuda.is_available()
+
+    if use_cuda:
+        device = torch.device(f"cuda:{rank}")
+    else:
+        device = torch.device("cpu")
+        enable_amp = False  # AMP not supported on CPU
+
+    # -------- Debug Info (important) --------
+    print(f"[INFO] Rank: {rank} | Device: {device} | AMP: {enable_amp}")
+
+    # -------- Trainer Init --------
+    trainer = Trainer(
+        rank=rank,
+        cfg=cfg,
+        enable_amp=enable_amp,
+        device=device  # <-- enforce device injection
+    )
+
     trainer.sequential_training()
 
 
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Train VOS")
+
     parser.add_argument('--exp_name', type=str, default='')
     parser.add_argument('--stage', type=str, default='pre')
     parser.add_argument('--model', type=str, default='aott')
@@ -34,7 +52,6 @@ def main():
     parser.set_defaults(amp=False)
 
     parser.add_argument('--pretrained_path', type=str, default='')
-
     parser.add_argument('--datasets', nargs='+', type=str, default=[])
     parser.add_argument('--lr', type=float, default=-1.)
     parser.add_argument('--total_step', type=int, default=-1.)
@@ -42,16 +59,19 @@ def main():
 
     args = parser.parse_args()
 
+    # -------- Load Config --------
     engine_config = importlib.import_module('configs.' + args.stage)
-
     cfg = engine_config.EngineConfig(args.exp_name, args.model)
 
+    # -------- Override Config --------
     if len(args.datasets) > 0:
         cfg.DATASETS = args.datasets
 
     cfg.DIST_START_GPU = args.start_gpu
+
     if args.gpu_num > 0:
         cfg.TRAIN_GPUS = args.gpu_num
+
     if args.batch_size > 0:
         cfg.TRAIN_BATCH_SIZE = args.batch_size
 
@@ -70,18 +90,30 @@ def main():
     if args.start_step > 0:
         cfg.TRAIN_START_STEP = args.start_step
 
+    # -------- Dist URL --------
     if args.dist_url == '':
-        cfg.DIST_URL = 'tcp://127.0.0.1:123' + str(random.randint(0, 9)) + str(
-            random.randint(0, 9))
+        cfg.DIST_URL = 'tcp://127.0.0.1:123' + str(random.randint(0, 99))
     else:
         cfg.DIST_URL = args.dist_url
-        
-    if cfg.TRAIN_GPUS > 1:
-        # Use torch.multiprocessing.spawn to launch distributed processes
+
+    # -------- Device Mode Decision --------
+    use_cuda = torch.cuda.is_available()
+
+    if not use_cuda:
+        print("[INFO] CUDA not available → Running on CPU")
+        cfg.TRAIN_GPUS = 0
+        main_worker(0, cfg, enable_amp=False)
+
+    elif cfg.TRAIN_GPUS > 1:
+        print(f"[INFO] Multi-GPU Training on {cfg.TRAIN_GPUS} GPUs")
         mp.spawn(main_worker, nprocs=cfg.TRAIN_GPUS, args=(cfg, args.amp))
+
     else:
+        print("[INFO] Single GPU Training")
         cfg.TRAIN_GPUS = 1
-        main_worker(0, cfg, args.amp)
+        main_worker(0, cfg, enable_amp=args.amp)
+
 
 if __name__ == '__main__':
     main()
+    

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,10 +1,14 @@
 import importlib
 import os
+import sys
 import random
 import numpy as np
 import torch
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from networks.managers.trainer import Trainer
+sys.path.append('.')
+sys.path.append('..')
 
 # ----------------------------
 # Argument Parser
@@ -38,11 +42,6 @@ def parse_args():
 # ----------------------------
 def setup_runtime():
     use_cuda = torch.cuda.is_available()
-    if torch.cuda.device_count() > 1 and not distributed:
-        raise RuntimeError(
-            "Multiple GPUs detected but not using torchrun. "
-            "Launch with: torchrun --nproc_per_node=N train.py"
-        )
     # CPU fallback
     if not use_cuda:
         return {

--- a/train_eval.sh
+++ b/train_eval.sh
@@ -1,5 +1,5 @@
 exp="default"
-gpu_num="4"  
+gpu_num="4"
 #in case of no gpu, just don't include this argument
 
 model="aott"
@@ -16,13 +16,14 @@ python tools/train.py --amp \
 	--stage ${stage} \
 	--model ${model} \
 	--gpu_num ${gpu_num}
-	
+
 stage="pre_ytb_dav"
-python tools/train.py --amp \
-	--exp_name ${exp} \
-	--stage ${stage} \
-	--model ${model} \
-	--gpu_num ${gpu_num}
+# Single GPU
+python tools/train.py --exp_name ${exp} --stage ${stage} --model ${model}
+
+# Multi-GPU
+torchrun --nproc_per_node=4 tools/train.py --exp_name ${exp} --stage ${stage} --model ${model}
+
 
 ## Evaluation ##
 dataset="davis2017"

--- a/utils/checkpoint.py
+++ b/utils/checkpoint.py
@@ -4,14 +4,15 @@ import numpy as np
 from pathlib import Path
 
 
-def get_device(gpu=None):
-    if torch.cuda.is_available():
-        return torch.device(f"cuda:{gpu}" if gpu is not None else "cuda")
-    return torch.device("cpu")
+def get_device(device=None):
+    if isinstance(device, torch.device):
+        return device
+    if device is None:
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(f"cuda:{device}")
 
-
-def load_network_and_optimizer(net, opt, pretrained_dir, gpu=None, scaler=None):
-    device = get_device(gpu)
+def load_network_and_optimizer(net, opt, pretrained_dir,  device=None, scaler=None):
+    device = get_device(device)
     pretrained = torch.load(pretrained_dir, map_location=device, weights_only=False)
 
     pretrained_dict = pretrained['state_dict']
@@ -40,8 +41,8 @@ def load_network_and_optimizer(net, opt, pretrained_dir, gpu=None, scaler=None):
     return net.to(device), opt, pretrained_dict_remove
 
 
-def load_network_and_optimizer_v2(net, opt, pretrained_dir, gpu=None, scaler=None):
-    device = get_device(gpu)
+def load_network_and_optimizer_v2(net, opt, pretrained_dir,  device=None, scaler=None):
+    device = get_device(device)
     pretrained = torch.load(pretrained_dir, map_location=device, weights_only=False)
 
     pretrained_dict = pretrained['state_dict']
@@ -91,8 +92,8 @@ def load_network_and_optimizer_v2(net, opt, pretrained_dir, gpu=None, scaler=Non
     return net.to(device), opt, pretrained_dict_remove
 
 
-def load_network(net, pretrained_dir, gpu=None):
-    device = get_device(gpu)
+def load_network(net, pretrained_dir, device=None):
+    device = get_device(device)
     pretrained = torch.load(pretrained_dir, map_location=device, weights_only=False)
 
     if 'state_dict' in pretrained:

--- a/utils/checkpoint.py
+++ b/utils/checkpoint.py
@@ -4,12 +4,10 @@ import numpy as np
 from pathlib import Path
 
 
-def get_device(device=None):
-    if isinstance(device, torch.device):
-        return device
-    if device is None:
-        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    return torch.device(f"cuda:{device}")
+def get_device(device):
+    if not isinstance(device, torch.device):
+        raise TypeError("device must be torch.device")
+    return device
 
 def load_network_and_optimizer(net, opt, pretrained_dir,  device=None, scaler=None):
     device = get_device(device)

--- a/utils/math.py
+++ b/utils/math.py
@@ -1,12 +1,14 @@
 import torch
 
 def generate_permute_matrix(dim, num, keep_first=True, device=None, gpu_id=None):
-    # Backward-compatible path: existing callers may still pass gpu_id=...
+
     if device is None:
         if gpu_id is not None and torch.cuda.is_available():
             device = torch.device(f"cuda:{gpu_id}")
+        elif torch.cuda.is_available():
+            device = torch.device("cuda", torch.cuda.current_device())
         else:
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            device = torch.device("cpu")
 
     all_matrix = []
     for _ in range(num):


### PR DESCRIPTION
Fixes: #94 

Refactored the training pipeline to be fully device-agnostic (CPU/CUDA) and torchrun-compatible, introducing a unified CLI entrypoint and improving distributed training robustness, reproducibility, and maintainability.


                                            **** WORK UNDER PROGRESS  ****
  
  
Key Improvements
Device-agnostic Trainer
Reworked training manager to operate on torch.device instead of hardcoded CUDA paths
→ Eliminates device-specific failures and enables seamless CPU fallback for debugging and portability
Robust Distributed Training (DDP)
Added native support for torchrun (RANK, WORLD_SIZE, LOCAL_RANK)
Fixed metric aggregation using true world size
→ Ensures correctness and scalability across multi-GPU / multi-node setups
Unified Training Entrypoint (tools/train.py)
Centralized runtime setup, argument parsing, seeding, and config overrides
→ Simplifies experimentation, CI integration, and reproducible launches
Safe AMP Handling
Enabled mixed precision only when CUDA is available
→ Prevents runtime errors and improves training stability across environments
Device-aware Data Pipeline
Conditional pin_memory, prefetch_factor, and batch sizing based on runtime device
→ Optimizes data throughput without breaking CPU execution
Checkpointing API Refactor
Replaced GPU-index-based loading with explicit torch.device handling
→ Improves clarity, correctness, and cross-device compatibility
Cleaner Runtime Behavior
Removed unconditional torch.cuda.* calls
Added guarded device setup and distributed cleanup
→ Reduces silent bugs and improves reliability in mixed environments

Motivation:

This refactor removes implicit CUDA assumptions and replaces them with explicit, device-aware abstractions, making the training stack:

Portable → runs on CPU, single GPU, or distributed setups without code changes
Correct → fixes subtle DDP bugs (e.g., incorrect metric averaging)
Reproducible → centralized seeding and deterministic-ish behavior per rank
Production-ready → compatible with standard tooling (torchrun, CI pipelines, SLURM)
Maintainable → cleaner interfaces (torch.device) and reduced technical debt

