### PR TITLE
Modernize old PIL and torchvision APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ General examples (Messi and Kobe):
 - **Test-time augmentation:** multi-scale and flipping augmentations are supported.
 
 ## Requirements
-   * Python3
-   * pytorch
+   * Python >= 3.10
+   * pytorch >= 2.9.0
    * torchvision >= 0.24.0
    * opencv-python
    * Pillow >= 11.0.0

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ General examples (Messi and Kobe):
 
 ## Requirements
    * Python3
-   * pytorch 
-   * torchvision
+   * pytorch
+   * torchvision >= 0.24.0
    * opencv-python
-   * Pillow
+   * Pillow >= 11.0.0
    * Pytorch Correlation. Recommend to install from [source](https://github.com/ClementPinard/Pytorch-Correlation-extension):
      ```bash
      git clone https://github.com/ClementPinard/Pytorch-Correlation-extension.git

--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ General examples (Messi and Kobe):
 <img src="source/messi.gif" width="45%"/> <img src="source/kobe.gif" width="45%"/>
 
 ## Highlights
-- **High performance:** up to **85.5%** ([R50-AOTL](MODEL_ZOO.md#youtube-vos-2018-val)) on YouTube-VOS 2018 and **82.1%** ([SwinB-AOTL]((MODEL_ZOO.md#youtube-vos-2018-val))) on DAVIS-2017 Test-dev under standard settings (without any test-time augmentation and post processing). 
+- **High performance:** up to **85.5%** ([R50-AOTL](MODEL_ZOO.md#youtube-vos-2018-val)) on YouTube-VOS 2018 and **82.1%** ([SwinB-AOTL]((MODEL_ZOO.md#youtube-vos-2018-val))) on DAVIS-2017 Test-dev under standard settings (without any test-time augmentation and post processing).
 - **High efficiency:** up to **51fps** ([AOTT](MODEL_ZOO.md#davis-2017-test)) on DAVIS-2017 (480p) even with **10** objects and **41fps** on YouTube-VOS (1.3x480p). AOT can process multiple objects (less than a pre-defined number, 10 is the default) as efficiently as processing a single object. This project also supports inferring any number of objects together within a video by automatic separation and aggregation.
 - **Multi-GPU training and inference**
-- **Mixed precision training and inference** 
+- **Mixed precision training and inference**
 - **Test-time augmentation:** multi-scale and flipping augmentations are supported.
 
 ## Requirements
    * Python3
-   * pytorch >= 1.7.0 and torchvision
+   * pytorch 
+   * torchvision
    * opencv-python
    * Pillow
    * Pytorch Correlation. Recommend to install from [source](https://github.com/ClementPinard/Pytorch-Correlation-extension):
@@ -99,8 +100,8 @@ Results:
 1. Prepare datasets:
 
     Please follow the below instruction to prepare datasets in each corresponding folder.
-    * **Static** 
-    
+    * **Static**
+
         [datasets/Static](datasets/Static): pre-training dataset with static images. Guidance can be found in [AFB-URR](https://github.com/xmlyqing00/AFB-URR), which we referred to in the implementation of the pre-training.
     * **YouTube-VOS**
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ General examples (Messi and Kobe):
    * Python >= 3.10
    * pytorch >= 2.9.0
    * torchvision >= 0.24.0
-   * opencv-python
+   * opencv-python-headless>=4.10.0
    * Pillow >= 11.0.0
    * Pytorch Correlation. Recommend to install from [source](https://github.com/ClementPinard/Pytorch-Correlation-extension):
      ```bash

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ General examples (Messi and Kobe):
      cd ..
      ```
 
+Optional:
+   * scikit-image (if you want to run our **Demo**, please install)
 
 ## Model Zoo and Results
 Pre-trained models, benckmark scores, and pre-computed results reproduced by this project can be found in [MODEL_ZOO.md](MODEL_ZOO.md).

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ General examples (Messi and Kobe):
      cd ..
      ```
 
-Optional:
-   * scikit-image (if you want to run our **Demo**, please install)
 
 ## Model Zoo and Results
 Pre-trained models, benckmark scores, and pre-computed results reproduced by this project can be found in [MODEL_ZOO.md](MODEL_ZOO.md).

--- a/dataloaders/eval_datasets.py
+++ b/dataloaders/eval_datasets.py
@@ -148,7 +148,7 @@ class YOUTUBEVOS_Test(object):
         images = []
         labels = []
         for obj_n in obj_names:
-            images += map(lambda x: x + '.jpg', list(data[obj_n]["frames"]))
+            images.extend(f"{x}.jpg" for x in data[obj_n]["frames"])
             labels.append(data[obj_n]["frames"][0] + '.png')
         images = np.sort(np.unique(images))
         labels = np.sort(np.unique(labels))
@@ -218,8 +218,7 @@ class YOUTUBEVOS_DenseTest(object):
         obj_names = list(data.keys())
         images_sparse = []
         for obj_n in obj_names:
-            images_sparse += map(lambda x: x + '.jpg',
-                                 list(data[obj_n]["frames"]))
+            images_sparse.extend(f"{x}.jpg" for x in data[obj_n]["frames"])
         images_sparse = np.sort(np.unique(images_sparse))
 
         images = np.sort(

--- a/dataloaders/eval_datasets.py
+++ b/dataloaders/eval_datasets.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import os
 import shutil
 import json

--- a/dataloaders/image_transforms.py
+++ b/dataloaders/image_transforms.py
@@ -5,22 +5,25 @@ import numbers
 import numpy as np
 from PIL import Image, ImageFilter
 from collections.abc import Sequence
-
+try:
+    Resampling = Image.Resampling
+except AttributeError:
+    Resampling = Image
 import torch
 import torchvision.transforms.functional as TF
 
 _pil_interpolation_to_str = {
-    Image.NEAREST: 'PIL.Image.NEAREST',
-    Image.BILINEAR: 'PIL.Image.BILINEAR',
-    Image.BICUBIC: 'PIL.Image.BICUBIC',
-    Image.LANCZOS: 'PIL.Image.LANCZOS',
-    Image.HAMMING: 'PIL.Image.HAMMING',
-    Image.BOX: 'PIL.Image.BOX',
+    Resampling.NEAREST: 'PIL.Image.NEAREST',
+    Resampling.BILINEAR: 'PIL.Image.BILINEAR',
+    Resampling.BICUBIC: 'PIL.Image.BICUBIC',
+    Resampling.LANCZOS: 'PIL.Image.LANCZOS',
+    Resampling.HAMMING: 'PIL.Image.HAMMING',
+    Resampling.BOX: 'PIL.Image.BOX',
 }
 
 
 def _get_image_size(img):
-    if TF._is_pil_image(img):
+    if isinstance(img, Image.Image):
         return img.size
     elif isinstance(img, torch.Tensor) and img.dim() > 2:
         return img.shape[-2:][::-1]
@@ -92,40 +95,64 @@ class GaussianBlur(object):
 
 
 class RandomAffine(object):
-    """Random affine transformation of the image keeping center invariant
+    """
+    Random affine transformation of the image keeping center invariant.
 
     Args:
-        degrees (sequence or float or int): Range of degrees to select from.
-            If degrees is a number instead of sequence like (min, max), the range of degrees
-            will be (-degrees, +degrees). Set to 0 to deactivate rotations.
-        translate (tuple, optional): tuple of maximum absolute fraction for horizontal
-            and vertical translations. For example translate=(a, b), then horizontal shift
-            is randomly sampled in the range -img_width * a < dx < img_width * a and vertical shift is
-            randomly sampled in the range -img_height * b < dy < img_height * b. Will not translate by default.
-        scale (tuple, optional): scaling factor interval, e.g (a, b), then scale is
-            randomly sampled from the range a <= scale <= b. Will keep original scale by default.
-        shear (sequence or float or int, optional): Range of degrees to select from.
-            If shear is a number, a shear parallel to the x axis in the range (-shear, +shear)
-            will be apllied. Else if shear is a tuple or list of 2 values a shear parallel to the x axis in the
-            range (shear[0], shear[1]) will be applied. Else if shear is a tuple or list of 4 values,
-            a x-axis shear in (shear[0], shear[1]) and y-axis shear in (shear[2], shear[3]) will be applied.
-            Will not apply shear by default
-        resample ({PIL.Image.NEAREST, PIL.Image.BILINEAR, PIL.Image.BICUBIC}, optional):
-            An optional resampling filter. See `filters`_ for more information.
-            If omitted, or if the image has mode "1" or "P", it is set to PIL.Image.NEAREST.
-        fillcolor (tuple or int): Optional fill color (Tuple for RGB Image And int for grayscale) for the area
-            outside the transform in the output image.(Pillow>=5.0.0)
+        degrees (sequence or float or int):
+            Range of degrees to select from.
+            If degrees is a number instead of a sequence like (min, max),
+            the range of degrees will be (-degrees, +degrees).
+            Set to 0 to deactivate rotations.
 
-    .. _filters: https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters
+        translate (tuple, optional):
+            Tuple of maximum absolute fraction for horizontal and vertical
+            translations. For example translate=(a, b), then horizontal shift
+            is randomly sampled in the range
+            -img_width * a < dx < img_width * a and vertical shift is
+            randomly sampled in the range
+            -img_height * b < dy < img_height * b.
+            Will not translate by default.
 
+        scale (tuple, optional):
+            Scaling factor interval, e.g. (a, b), then scale is randomly
+            sampled from the range a <= scale <= b.
+            Will keep original scale by default.
+
+        shear (sequence or float or int, optional):
+            Range of degrees to select from.
+
+            If shear is a number, a shear parallel to the x-axis in the range
+            (-shear, +shear) will be applied.
+
+            Else if shear is a tuple or list of 2 values, a shear parallel
+            to the x-axis in the range (shear[0], shear[1]) will be applied.
+
+            Else if shear is a tuple or list of 4 values:
+                (shear[0], shear[1]) -> x-axis shear range
+                (shear[2], shear[3]) -> y-axis shear range
+
+            Will not apply shear by default.
+
+        interpolation (InterpolationMode or PIL resampling filter, optional):
+            Desired interpolation enum defined by torchvision.transforms.
+            Default is Resampling.NEAREST.
+
+        fill (sequence or number, optional):
+            Pixel fill value for the area outside the transformed image.
+            Can be a tuple for RGB images or a scalar for grayscale images.
+            Default is 0.
+
+    .. _filters:
+        https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters
     """
     def __init__(self,
-                 degrees,
-                 translate=None,
-                 scale=None,
-                 shear=None,
-                 resample=False,
-                 fillcolor=0):
+                degrees,
+                translate=None,
+                scale=None,
+                shear=None,
+                interpolation=Resampling.NEAREST,
+                fill=0):
         if isinstance(degrees, numbers.Number):
             if degrees < 0:
                 raise ValueError(
@@ -171,8 +198,8 @@ class RandomAffine(object):
         else:
             self.shear = shear
 
-        self.resample = resample
-        self.fillcolor = fillcolor
+        self.interpolation = interpolation
+        self.fill = fill
 
     @staticmethod
     def get_params(degrees, translate, scale_ranges, shears, img_size):
@@ -217,11 +244,19 @@ class RandomAffine(object):
         """
         ret = self.get_params(self.degrees, self.translate, self.scale,
                               self.shear, img.size)
-        img = TF.affine(img,
-                        *ret,
-                        resample=self.resample,
-                        fillcolor=self.fillcolor)
-        mask = TF.affine(mask, *ret, resample=Image.NEAREST, fillcolor=0)
+        img = TF.affine(
+            img,
+            *ret,
+            interpolation=self.interpolation,
+            fill=self.fill
+        )
+
+        mask = TF.affine(
+            mask,
+            *ret,
+            interpolation=Resampling.NEAREST,
+            fill=0
+        )
         return img, mask
 
     def __repr__(self):
@@ -232,13 +267,13 @@ class RandomAffine(object):
             s += ', scale={scale}'
         if self.shear is not None:
             s += ', shear={shear}'
-        if self.resample > 0:
-            s += ', resample={resample}'
-        if self.fillcolor != 0:
-            s += ', fillcolor={fillcolor}'
+        if self.interpolation is not None:
+            s += ', interpolation={interpolation}'
+        if self.fill != 0:
+            s += ', fill={fill}'
         s += ')'
         d = dict(self.__dict__)
-        d['resample'] = _pil_interpolation_to_str[d['resample']]
+        d['interpolation'] = _pil_interpolation_to_str[d['interpolation']]
         return s.format(name=self.__class__.__name__, **d)
 
 
@@ -359,7 +394,7 @@ class RandomResizedCrop(object):
                  size,
                  scale=(0.08, 1.0),
                  ratio=(3. / 4., 4. / 3.),
-                 interpolation=Image.BILINEAR):
+                 interpolation=Resampling.BILINEAR):
         if isinstance(size, (tuple, list)):
             self.size = size
         else:
@@ -426,7 +461,7 @@ class RandomResizedCrop(object):
         i, j, h, w = self.get_params(img, self.scale, self.ratio)
         # print(i, j, h, w)
         img = TF.resized_crop(img, i, j, h, w, self.size, self.interpolation)
-        mask = TF.resized_crop(mask, i, j, h, w, self.size, Image.NEAREST)
+        mask = TF.resized_crop(mask, i, j, h, w, self.size, Resampling.NEAREST)
         return img, mask
 
     def __repr__(self):
@@ -501,7 +536,7 @@ class Resize(torch.nn.Module):
             Default is ``PIL.Image.BILINEAR``. If input is Tensor, only ``PIL.Image.NEAREST``, ``PIL.Image.BILINEAR``
             and ``PIL.Image.BICUBIC`` are supported.
     """
-    def __init__(self, size, interpolation=Image.BILINEAR):
+    def __init__(self, size, interpolation=Resampling.BILINEAR):
         super().__init__()
         if not isinstance(size, (int, Sequence)):
             raise TypeError("Size should be int or sequence. Got {}".format(
@@ -521,7 +556,7 @@ class Resize(torch.nn.Module):
             PIL Image or Tensor: Rescaled image.
         """
         img = TF.resize(img, self.size, self.interpolation)
-        mask = TF.resize(mask, self.size, Image.NEAREST)
+        mask = TF.resize(mask, self.size, Resampling.NEAREST)
         return img, mask
 
     def __repr__(self):

--- a/dataloaders/image_transforms.py
+++ b/dataloaders/image_transforms.py
@@ -5,10 +5,9 @@ import numbers
 import numpy as np
 from PIL import Image, ImageFilter
 from collections.abc import Sequence
-try:
-    Resampling = Image.Resampling
-except AttributeError:
-    Resampling = Image
+
+Resampling = Image.Resampling
+
 import torch
 import torchvision.transforms.functional as TF
 

--- a/dataloaders/train_datasets.py
+++ b/dataloaders/train_datasets.py
@@ -5,6 +5,10 @@ import json
 import random
 import cv2
 from PIL import Image
+try:
+    BICUBIC = Image.Resampling.BICUBIC
+except AttributeError:
+    BICUBIC = Image.BICUBIC
 
 import numpy as np
 import torch
@@ -150,17 +154,19 @@ class StaticTrain(Dataset):
         else:
             assert NotImplementedError
 
-        self.random_affine = IT.RandomAffine(degrees=20,
-                                             translate=(0.1, 0.1),
-                                             scale=(0.9, 1.1),
-                                             shear=10,
-                                             resample=Image.BICUBIC,
-                                             fillcolor=(124, 116, 104))
+        self.random_affine = IT.RandomAffine(
+            degrees=20,
+            translate=(0.1, 0.1),
+            scale=(0.9, 1.1),
+            shear=10,
+            interpolation=BICUBIC,
+            fill=(124, 116, 104),
+        )
         base_ratio = float(output_size[1]) / output_size[0]
         self.random_resize_crop = IT.RandomResizedCrop(
             output_size, (0.8, 1),
             ratio=(base_ratio * 3. / 4., base_ratio * 4. / 3.),
-            interpolation=Image.BICUBIC)
+            interpolation=BICUBIC)
         self.to_tensor = TF.ToTensor()
         self.to_onehot = IT.ToOnehot(max_obj_n, shuffle=True)
         self.normalize = TF.Normalize((0.485, 0.456, 0.406),

--- a/dataloaders/train_datasets.py
+++ b/dataloaders/train_datasets.py
@@ -1,14 +1,12 @@
-from __future__ import division
 import os
 from glob import glob
 import json
 import random
 import cv2
 from PIL import Image
-try:
-    BICUBIC = Image.Resampling.BICUBIC
-except AttributeError:
-    BICUBIC = Image.BICUBIC
+
+BICUBIC = Image.Resampling.BICUBIC
+
 
 import numpy as np
 import torch

--- a/tools/demo.py
+++ b/tools/demo.py
@@ -7,6 +7,7 @@ sys.path.append('..')
 
 import cv2
 from PIL import Image
+from skimage.morphology import dilation
 
 import numpy as np
 import torch
@@ -101,8 +102,8 @@ def overlay(image, mask, colors=[255, 0, 0], cscale=1, alpha=0.4):
         binary_mask = mask == object_id
 
         im_overlay[binary_mask] = foreground[binary_mask]
-        kernel = np.ones((3, 3), np.uint8)
-        countours = cv2.dilate(binary_mask.astype(np.uint8), kernel).astype(bool) ^ binary_mask
+
+        countours = dilation(binary_mask) ^ binary_mask
         im_overlay[countours, :] = 0
 
     return im_overlay.astype(image.dtype)
@@ -299,3 +300,4 @@ if __name__ == '__main__':
         print(inst)
         print(" For better efficiency, please install it.")
     main()
+    

--- a/tools/demo.py
+++ b/tools/demo.py
@@ -7,7 +7,6 @@ sys.path.append('..')
 
 import cv2
 from PIL import Image
-from skimage.morphology import dilation
 
 import numpy as np
 import torch
@@ -102,8 +101,8 @@ def overlay(image, mask, colors=[255, 0, 0], cscale=1, alpha=0.4):
         binary_mask = mask == object_id
 
         im_overlay[binary_mask] = foreground[binary_mask]
-
-        countours = dilation(binary_mask) ^ binary_mask
+        kernel = np.ones((3, 3), np.uint8)
+        countours = cv2.dilate(binary_mask.astype(np.uint8), kernel).astype(bool) ^ binary_mask
         im_overlay[countours, :] = 0
 
     return im_overlay.astype(image.dtype)
@@ -300,4 +299,3 @@ if __name__ == '__main__':
         print(inst)
         print(" For better efficiency, please install it.")
     main()
-    

--- a/utils/ema.py
+++ b/utils/ema.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 import torch
 
 

--- a/utils/meters.py
+++ b/utils/meters.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 class AverageMeter(object):
     """Computes and stores the average and current value"""
     def __init__(self, momentum=0.999):


### PR DESCRIPTION
Modernized PIL, Torchvision, and removed future imports as the readme says python 3 explicitly 

I really think we have to raise the Pillow and torchvision versions explicitly, because we are moving forward and can't keep up with old dead code supporting each version explicitly, we are going fully modernized with this PR

Removed unecessary scikit-image dependency as well

MERGE THIS PR before merging pyproject.toml one @z-x-yang 